### PR TITLE
**DRAFT**: Send secret masking telemetry if opted in to it.

### DIFF
--- a/src/Agent.Sdk/Agent.Sdk.csproj
+++ b/src/Agent.Sdk/Agent.Sdk.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Security.Utilities.Core" Version="1.17.0" />
+    <PackageReference Include="Microsoft.Security.Utilities.Core" Version="[1.17.0-g8bce0eabf1]" />
     <PackageReference Include="Microsoft.Win32.Registry" Version="5.0.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="6.0.0-preview.5.21301.5" />
     <PackageReference Include="System.Management" Version="4.7.0" />

--- a/src/Agent.Sdk/Knob/AgentKnobs.cs
+++ b/src/Agent.Sdk/Knob/AgentKnobs.cs
@@ -681,6 +681,13 @@ namespace Agent.Sdk.Knob
             new EnvironmentKnobSource("AZP_ENABLE_NEW_MASKER_AND_REGEXES"),
             new BuiltInDefaultKnobSource("false"));
 
+        public static readonly Knob SendSecretMaskerTelemetry = new Knob(
+            nameof(SendSecretMaskerTelemetry),
+            "If true, the agent will send telemetry about secret masking",
+            new RuntimeKnobSource("AZP_SEND_SECRET_MASKER_TELEMETRY"),
+            new EnvironmentKnobSource("AZP_SEND_SECRET_MASKER_TELEMETRY"),
+            new BuiltInDefaultKnobSource("false"));
+
         public static readonly Knob AddDockerInitOption = new Knob(
             nameof(AddDockerInitOption),
             "If true, the agent will create docker container with the --init option.",

--- a/src/Agent.Sdk/SecretMasking/ILoggedSecretMasker.cs
+++ b/src/Agent.Sdk/SecretMasking/ILoggedSecretMasker.cs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
-
+using System.Collections.Generic;
 using Microsoft.TeamFoundation.DistributedTask.Logging;
 
 namespace Agent.Sdk.SecretMasking
@@ -19,5 +19,8 @@ namespace Agent.Sdk.SecretMasking
         void AddValue(String value, string origin);
         void AddValueEncoder(ValueEncoder encoder, string origin);
         void SetTrace(ITraceWriter trace);
+
+        bool HasTelemetry { get; }
+        void AddTelemetryDataTo(Dictionary<string, string> telemetryData);
     }
 }

--- a/src/Agent.Sdk/SecretMasking/LoggedSecretMasker.cs
+++ b/src/Agent.Sdk/SecretMasking/LoggedSecretMasker.cs
@@ -2,7 +2,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 using System;
-
+using System.Collections.Generic;
 using Microsoft.TeamFoundation.DistributedTask.Logging;
 
 namespace Agent.Sdk.SecretMasking
@@ -161,6 +161,16 @@ namespace Agent.Sdk.SecretMasking
                     disposable.Dispose();
                 }
                 _secretMasker = null;
+            }
+        }
+
+        public bool HasTelemetry => _secretMasker is OssSecretMasker ossMasker && ossMasker.HasTelemetry;
+
+        public void AddTelemetryDataTo(Dictionary<string, string> telemetryData)
+        {
+            if (_secretMasker is OssSecretMasker ossMasker)
+            {
+                ossMasker.AddTelemetryDataTo(telemetryData);
             }
         }
     }

--- a/src/NuGet.Config
+++ b/src/NuGet.Config
@@ -4,5 +4,6 @@
     <!--To inherit the global NuGet package sources remove the <clear/> line below -->
     <clear />
     <add key="restsdk" value="https://pkgs.dev.azure.com/mseng/PipelineTools/_packaging/nugetvssprivate/nuget/v3/index.json"/>
+    <add key="local" value="D:\Src\security-utilities\bld\nupkg\AnyCPU_Release" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
If using the new OSS secret masker and an additional opt-in knob is turned on, then send telemetry about secrets that were masked.